### PR TITLE
Fix problem where headings were cut off by fixed nav after in-page jumps...

### DIFF
--- a/views/2014/home.haml
+++ b/views/2014/home.haml
@@ -44,8 +44,9 @@
         %a.get-ticket(href="http://rubyconfau2014.eventbrite.com.au")
           get your ticket now.
 
-%section#speakers
+%section.speakers-section
   .row
+    %a(name="speakers")
     %h1(data-magellan-destination="speakers") Speakers
     %a.speakers-list(href="http://lanyrd.com/2014/rubyconf-au/") View full speakers list
     %article.speaker
@@ -93,7 +94,7 @@
           %span.icon.ss-octocat
           github.com/amyhoy
 
-%section#sessions
+%section.sessions-section
   .row
     %a(name="sessions")
     %h1(data-magellan-destination="sessions") Sessions
@@ -110,8 +111,9 @@
         to use on the day, or use the
         %a(href="https://m.lanyrd.com/2014/rubyconf-au/") Lanyrd mobile HTML5 site.
 
-%section#workshops
+%section.workshops-section
   .row
+    %a(name="workshops")
     %h1(data-magellan-destination="workshops") Workshops
     %a(href='http://goo.gl/maps/lxpO8' class='location') Location: Vibe Hotel North Sydney
     %article.workshop
@@ -191,9 +193,10 @@
         %a.twitter(href="https://twitter.com/railsgirlsau" class="twitter") @railsgirlsau
         %a.get-ticket(href="http://rubyconfau2014.eventbrite.com.au") Sign up for the workshop
 
-%section#venue(data-magellan-destination="venue")
+%section.venue-section
   .row
-    %div
+    %a(name="venue")
+    %div(data-magellan-destination="venue")
       %h1 Our Venue
       %p RubyConfAU is being held at the Crystal Palace at Luna Park, right on Sydney Harbour and under the shadow of the Sydney Harbour Bridge.
 
@@ -213,8 +216,9 @@
         %a(href="/social" class='inverted') handy list
         to help you out.
 
-%section#sponsors
+%section.sponsors-section
   .row
+    %a(name="sponsors")
     %h1(data-magellan-destination="sponsors") Sponsors
     %p RubyConfAU Sydney 2014 is made possible through the generous support of our sponsors.
     %article.sponsors.ruby

--- a/views/2014/styles/_nav.scss
+++ b/views/2014/styles/_nav.scss
@@ -57,3 +57,12 @@ section#nav {
     left: 1.8rem;
   }
 }
+
+// account for fixed header
+a[name] {
+  position: relative;
+  top: -60px;
+  display: block;
+  width: 0;
+  height: 0;
+}

--- a/views/2014/styles/_sessions.scss
+++ b/views/2014/styles/_sessions.scss
@@ -1,4 +1,4 @@
-#sessions {
+.sessions-section {
   background: $yellow;
 
   hgroup {
@@ -17,12 +17,12 @@
 }
 
 @media only screen and (max-width: 767px) {
-  section#sessions {
+  .sessions-section {
     hgroup { width: 85%; }
   }
 }
 @media only screen and (max-width: 480px) {
-  section#sessions {
+  .sessions-section {
     hgroup { width: 90%; }
   }
 }

--- a/views/2014/styles/_speakers.scss
+++ b/views/2014/styles/_speakers.scss
@@ -1,4 +1,4 @@
-#speakers {
+.speakers-section {
   background: $xlight_blue_bkg;
   padding-bottom: 2rem;
 
@@ -49,7 +49,7 @@
 
 
 @media only screen and (max-width: 500px) {
-  section#speakers {
+  .speakers-section {
     .speaker {
       width: 95%;
       display: block;

--- a/views/2014/styles/_sponsors.scss
+++ b/views/2014/styles/_sponsors.scss
@@ -1,4 +1,4 @@
-#sponsors {
+.sponsors-section {
  background: #fff;
 
  article.sponsors {
@@ -24,7 +24,7 @@
 }
 
 @media only screen and (max-width: 480px) {
-  #sponsors {
+  .sponsors-section {
     article.sponsors { width: 95%; }
     article.sponsors.misc .article { width: 45%; }
 

--- a/views/2014/styles/_venue.scss
+++ b/views/2014/styles/_venue.scss
@@ -1,4 +1,4 @@
-#venue {
+.venue-section {
   background: url(/images/2014/at_night.jpg) center 55% no-repeat;
   -webkit-background-size: cover;
   -moz-background-size: cover;
@@ -41,14 +41,14 @@
 }
 
 @media only screen and (min-width: 1650px) {
-  #venue .row div {
+  .venue-section .row div {
     width: 20%;
     height: 70%;
   }
 }
 
 @media only screen and (max-width: 1024px) {
-  #venue .row div {
+  .venue-section .row div {
     width: 50%;
 
     h3 { margin-top: 1.6rem; }
@@ -56,7 +56,7 @@
 }
 
 @media only screen and (max-width: 480px) {
-  #venue .row div {
+  .venue-section .row div {
     h1 { margin-bottom: 0.2rem; }
     h1 + p { display: none; }
   }

--- a/views/2014/styles/_workshops.scss
+++ b/views/2014/styles/_workshops.scss
@@ -1,4 +1,4 @@
-#workshops {
+.workshops-section {
   background: $light_blue_bkg;
   padding-bottom: 2rem;
 
@@ -72,7 +72,7 @@
 }
 
 @media only screen and (max-width: 767px) {
-  section#workshops {
+  .workshops-section {
     img.icon {
       width: 25%;
       height: 25%;
@@ -87,7 +87,7 @@
 }
 
 @media only screen and (max-width: 500px) {
-  section#workshops {
+  .workshops-section {
     article.workshop {
       width: 95%;
     }


### PR DESCRIPTION
This problem was caused by divs interfering with in-page anchors. I think it's better to avoid id tags completely unless you are applying javascript.

Also for future reference:

Don't use section tags as general purpose tags. They indicate semantic sections of a document, not the header, footer or nav - those things have their own HTML5 tags.

http://html5doctor.com/the-section-element/

Also, FYI, your media queries could be much sassier:

http://css-tricks.com/media-queries-sass-3-2-and-codekit/

:-)
