### PR TITLE
Add links to the hub

### DIFF
--- a/views/2014/home.haml
+++ b/views/2014/home.haml
@@ -38,7 +38,7 @@
       %h2
         It's time to bring the leading developers from around the region and beyond together for the second Ruby conference to be held in Australia.
         %br
-        %a.whos-speaking(href="http://lanyrd.com/2014/rubyconf-au/")
+        %a.whos-speaking(href="http://rubyconfau.multifaceted.io/speakers")
           See who's speaking
         or
         %a.get-ticket(href="http://rubyconfau2014.eventbrite.com.au")
@@ -47,7 +47,7 @@
 %section#speakers
   .row
     %h1(data-magellan-destination="speakers") Speakers
-    %a.speakers-list(href="http://lanyrd.com/2014/rubyconf-au/") View full speakers list
+    %a.speakers-list(href="http://rubyconfau.multifaceted.io/speakers") View full speakers list
     %article.speaker
       %img(src="/images/2014/speakers/cambarrie.png")
       %h3 Cameron Barrie
@@ -105,6 +105,10 @@
         %a(href="https://twitter.com/dymaxion" class="twitter")
           %span.icon.ss-twitter
           @dymaxion
+  .row
+    %h2
+      See interviews with the speakers at the
+      %a(href="http://rubyconfau.multifaceted.io/speakers" target="_blank") RubyConf AU Hub.
 
 %section#sessions
   .row
@@ -114,14 +118,11 @@
       %h2
         RubyConfAU sessions will run across two days: February 20-21 at the Luna Park Crystal Palace.
 
-        %a(href="http://lanyrd.com/2014/rubyconf-au/schedule/")
-          Full session details are available on Lanyrd.
+        %a(href="http://rubyconfau.multifaceted.io" target="_blank")
+          Full session details are available on the Hub.
 
       %p
-        Download the
-        %a(href="https://itunes.apple.com/us/app/lanyrd/id467652813") Lanyrd iPhone app
-        to use on the day, or use the
-        %a(href="https://m.lanyrd.com/2014/rubyconf-au/") Lanyrd mobile HTML5 site.
+        (It works on your mobile too!)
 
 %section#workshops
   .row

--- a/views/2014/styles/_speakers.scss
+++ b/views/2014/styles/_speakers.scss
@@ -15,6 +15,12 @@
     font-weight: 200;
   }
 
+  h2 a {
+    background: $purple;
+    color: white;
+    padding: 6px;
+  }
+
   .speaker {
     position: relative;
     display: inline-block;


### PR DESCRIPTION
I opted to change the links to Lanyrd to the hub (since you can actually see the sessions in each room against each other).

I'd hold off on deploying this until I properly get the rooms sorted on the Hub, which will be some time early this afternoon.

Let me know if there's any issues.
