### PR TITLE
Fix links.

### DIFF
--- a/views/2015/layout.haml
+++ b/views/2015/layout.haml
@@ -24,13 +24,13 @@
       %h3 Elsewhere
       %ul.body-section--event-footer__links
         %li
-          %a(href="") Twitter
-          %a(href="") Facebook
-          %a(href="") Vimeo
-          %a(href="") Lanyrd
+          %a(href="https://twitter.com/rubyconf_au") Twitter
+          %a(href="https://www.facebook.com/RubyConfAustralia") Facebook
+          %a(href="http://vimeo.com/channels/699773") Vimeo
+          %a(href="http://lanyrd.com/2015/rubyconf-au/") Lanyrd
       %h3 Mailing List
       %p.body-section--event-footer__links
         %a(href="https://confirmsubscription.com/h/j/F0AA131FF2C0F0B0") Join the mailing list
     %section#contact.body-section--previous-years
       %h2 Previous Years
-      %p <a href="/2013">2014</a> <a href="/2014">2014</a>
+      %p <a href="/2013">2013</a> <a href="/2014">2014</a>


### PR DESCRIPTION
Provides links that were missing under "Elsewhere". Note that the Vimeo link is to the 2014 videos.

Also fixes a typo in the links to previous years.
