### PR TITLE
Fixes HTTP 500 on file-not-found.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -24,6 +24,11 @@ helpers do
   end
 end
 
+# Haml file-not-found exception bubbling up from the depths.
+error Errno::ENOENT do
+  halt(404)
+end
+
 # 2013
 
 get '/2013/?' do


### PR DESCRIPTION
Intercepts Haml file-not-found template-rendering exceptions so that Errno::ENOENT doesn't cause the app to throw HTTP 500 when visiting, say, http://rubyconf.org.au/2015/speakerss or something.

(Fix does not appear in development due to https://github.com/sinatra/sinatra/issues/578; run `env RACK_ENV=production foreman start` to test as fake-production.)
