### PR TITLE
Quick navbar path bugfix

### DIFF
--- a/views/2017/_header.haml
+++ b/views/2017/_header.haml
@@ -18,14 +18,14 @@
         .top-bar-right
           %ul.menu.vertical.medium-horizontal
             %li
-              %a{href: '/2017/#location'}
+              %a{href: '/2017#location'}
                 Location
             %li
-              %a{href: '/2017/#speakers'}
+              %a{href: '/2017#speakers'}
                 Speakers
             %li
-              %a{href: '/2017/#sponsors'}
+              %a{href: '/2017#sponsors'}
                 Sponsors
             %li
-              %a{href: '/2017/#attending'}
+              %a{href: '/2017#attending'}
                 Attending


### PR DESCRIPTION
**Problem**
The current nav URLs cause assets to fail due to the path structure. (http://rubyconf.org.au/2017/#location)

**Solution**
By removing the slash the link anchors work as intended.