### PR TITLE
Downgrade Sass slightly to get newer Compass.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.3.5'
 gem "activesupport", '~> 4.2.8', require: "active_support/inflector"
 gem "createsend", "1.0.4"
 gem "compass"
+gem "sass", "~> 3.4.0"
 gem "json"
 gem "haml"
 gem "pony"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,18 @@ GEM
       tzinfo (~> 1.1)
     backports (3.8.0)
     chunky_png (1.3.8)
-    compass (0.12.2)
+    compass (1.0.3)
       chunky_png (~> 1.2)
-      fssm (>= 0.2.7)
-      sass (~> 3.1)
+      compass-core (~> 1.0.2)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.3)
+      multi_json (~> 1.0)
+      sass (>= 3.3.0, < 3.5)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
     createsend (1.0.4)
       hashie (~> 1.0)
       httparty (~> 0.8)
@@ -21,7 +29,6 @@ GEM
     ffi (1.9.18)
     foreman (0.84.0)
       thor (~> 0.19.1)
-    fssm (0.2.10)
     haml (5.0.3)
       temple (>= 0.8.0)
       tilt
@@ -47,11 +54,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    sass (3.5.1)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    sass (3.4.25)
     sinatra (2.0.0)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -88,6 +91,7 @@ DEPENDENCIES
   haml
   json
   pony
+  sass (~> 3.4.0)
   sinatra
   sinatra-contrib
   thin


### PR DESCRIPTION
Seems the latest Sass (v3.5.x) doesn't work with the latest Compass, but older versions of Compass (incorrectly) are convinced they'll work fine with it.

This change will ensure a more modern Compass release will be used (v1), but with a slightly older Sass release (v3.4.x). This has already been pushed to production to ensure the site's up and running, so further pushes may require a `--force`.