### PR TITLE
Add redirect for 2024

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,6 +13,7 @@ require_relative 'app/year_2018/app'
 require_relative 'app/year_2019/app'
 require_relative 'app/year_2020/app'
 require_relative 'app/year_2023/app'
+require_relative 'app/year_2024/app'
 
 module RubyConf
   class App < Sinatra::Application
@@ -49,6 +50,7 @@ module RubyConf
     register Year2019::App
     register Year2020::App
     register Year2023::App
+    register Year2024::App
 
     get '/' do
       status_code 302

--- a/app/year_2024/app.rb
+++ b/app/year_2024/app.rb
@@ -1,0 +1,21 @@
+require 'sinatra/base'
+require 'sinatra/namespace'
+
+module RubyConf
+  module Year2024
+    module App
+      def self.registered(app)
+        app.register Sinatra::Namespace
+
+        app.namespace '/2024' do
+          get do
+            puts "hello"
+            redirect 'https://2024.rubyconf.au/'
+          end
+        end
+      end
+    end
+  end
+
+  Sinatra.register Year2024::App
+end


### PR DESCRIPTION
I keep going to rubyconf.org.au in my browser but seeing 2023, but there is a 2024 site. Maybe we should redirect there?

### Before

<img width="1552" alt="image" src="https://github.com/rubyaustralia/ruby-conf-au/assets/14028/8b28f403-f8fc-47b6-8c1a-55222b40723a">

or

<img width="1552" alt="Screenshot 2024-01-27 at 10 25 34 am" src="https://github.com/rubyaustralia/ruby-conf-au/assets/14028/9b23206d-de87-48f9-98a0-6087ed3b4f45">

### After

<img width="1552" alt="image" src="https://github.com/rubyaustralia/ruby-conf-au/assets/14028/247575db-e478-4203-9f24-2feed50b77a8">
